### PR TITLE
Feat/#13: 마이페이지 구현 및 로그인 정보 받아오기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react-router": "^7.1.1",
         "react-router-dom": "^7.1.1",
         "react-toastify": "^11.0.5",
-        "styled-components": "^6.1.14",
+        "styled-components": "^6.1.19",
         "styled-reset": "^4.5.2"
       },
       "devDependencies": {
@@ -3173,16 +3173,17 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.14",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.14.tgz",
-      "integrity": "sha512-KtfwhU5jw7UoxdM0g6XU9VZQFV4do+KrM8idiVCH5h4v49W+3p3yMe0icYwJgZQZepa5DbH04Qv8P0/RdcLcgg==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
         "@types/stylis": "4.2.5",
         "css-to-react-native": "3.2.0",
         "csstype": "3.1.3",
-        "postcss": "8.4.38",
+        "postcss": "8.4.49",
         "shallowequal": "1.1.0",
         "stylis": "4.3.2",
         "tslib": "2.6.2"
@@ -3200,9 +3201,9 @@
       }
     },
     "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3217,10 +3218,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-router": "^7.1.1",
     "react-router-dom": "^7.1.1",
     "react-toastify": "^11.0.5",
-    "styled-components": "^6.1.14",
+    "styled-components": "^6.1.19",
     "styled-reset": "^4.5.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,12 @@ import { theme } from './styles/theme';
 import GlobalStyles from '@/styles/GlobalStyles';
 import Layout from '@/components/layout/Layout';
 import CustomToastContainer from '@/components/toast/Toast';
+import AuthLoader from './components/auth/AuthLoader';
 
 function App() {
   return (
     <BrowserRouter>
+      <AuthLoader />
       <CustomToastContainer />
       <ThemeProvider theme={theme}>
         <GlobalStyles />

--- a/src/apis/apiRoutes.ts
+++ b/src/apis/apiRoutes.ts
@@ -2,4 +2,5 @@ export const API_ROUTES = {
   LOGIN: '/users/login',
   SIGNUP: '/users',
   LOGOUT: '/users/logout',
+  MY_INFO: '/users/my',
 };

--- a/src/apis/auth.api.ts
+++ b/src/apis/auth.api.ts
@@ -13,12 +13,7 @@ export const login = async (data: LoginFormInputs): Promise<{ accessToken: strin
   try {
     const response = await axiosInstance.post(API_ROUTES.LOGIN, data);
 
-    console.log('----- 로그인 API 응답 -----');
-    console.log('로그인 응답:', response);
-    console.log('응답 데이터 (response.data): ', response.data);
-
     const accessToken = response.data.data;
-    console.log('accessToken: ', accessToken);
 
     if (accessToken) {
       return { accessToken };
@@ -33,17 +28,9 @@ export const login = async (data: LoginFormInputs): Promise<{ accessToken: strin
 };
 
 // 내 정보 조회
-export const getMyInfo = async (token?: string): Promise<User> => {
+export const getMyInfo = async (): Promise<User> => {
   try {
-    const response = await axiosInstance.get(API_ROUTES.MY_INFO, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-
-    console.log('----- 내 정보 API 응답 -----');
-    console.log('전체 응답 객체 : ', response);
-    console.log('응답 데이터 (response.data): ', response.data);
-
-    console.log('응답 데이터 response.data.data: ', response.data.data);
+    const response = await axiosInstance.get(API_ROUTES.MY_INFO);
 
     return response.data.data;
   } catch (error) {
@@ -68,7 +55,6 @@ export const logout = async () => {
 export const signUp = async (data: SignupFormInputs) => {
   try {
     const response = await axiosInstance.post(API_ROUTES.SIGNUP, data);
-    console.log('회원가입 응답:', response);
 
     return response;
   } catch (error) {
@@ -84,12 +70,6 @@ export const signUp = async (data: SignupFormInputs) => {
 export const patchMyInfo = async (data: UpdateMyInfoPayload): Promise<User> => {
   try {
     const response = await axiosInstance.patch(API_ROUTES.MY_INFO, data);
-
-    console.log('----- 내 정보 수정 API 응답 -----');
-    console.log('전체 응답 객체 : ', response);
-    console.log('응답 데이터 (response.data): ', response.data);
-
-    console.log('응답 데이터 response.data.data: ', response.data.data);
 
     return response.data.data;
   } catch (error) {

--- a/src/apis/auth.api.ts
+++ b/src/apis/auth.api.ts
@@ -1,4 +1,9 @@
-import { LoginFormInputs, SignupFormInputs, User } from '@/interfaces/auth.interfaces';
+import {
+  LoginFormInputs,
+  SignupFormInputs,
+  UpdateMyInfoPayload,
+  User,
+} from '@/interfaces/auth.interfaces';
 import axiosInstance from '@/apis/axiosInstance.api';
 import { API_ROUTES } from '@/apis/apiRoutes';
 import { toast } from 'react-toastify';
@@ -75,41 +80,24 @@ export const signUp = async (data: SignupFormInputs) => {
   }
 };
 
-/*
+// 내 정보 수정
+export const patchMyInfo = async (data: UpdateMyInfoPayload): Promise<User> => {
+  try {
+    const response = await axiosInstance.patch(API_ROUTES.MY_INFO, data);
+
+    console.log('----- 내 정보 수정 API 응답 -----');
+    console.log('전체 응답 객체 : ', response);
+    console.log('응답 데이터 (response.data): ', response.data);
+
+    console.log('응답 데이터 response.data.data: ', response.data.data);
+
+    return response.data.data;
+  } catch (error) {
+    console.error('내 정보 수정 API 호출 에러 발생: ', error);
+    throw new Error('사용자 정보를 가져오는데 실패했습니다.');
+  }
+};
 
 // 이메일 중복 확인 API
-export const checkEmailDuplicate = async (email: string): Promise<boolean> => {
-  try {
-    // 백엔드와 협의된 중복 확인 API 엔드포인트 사용
-    // 예: GET /api/v1/users/check-email?email=...
-    const response = await axiosInstance.get(API_ROUTES.CHECK_EMAIL, { params: { email } });
-    console.log('이메일 중복 확인 응답:', response);
-
-    // 백엔드 응답 구조에 따라 중복 여부를 판단합니다.
-    // 예: { isDuplicate: true/false } 형태로 응답이 온다고 가정
-    return response.data.isDuplicate; // <<< 백엔드 응답 구조에 맞게 수정
-  } catch (error) {
-    console.error('이메일 중복 확인 API 호출 에러 발생:', error);
-    // API 호출 자체에서 에러가 난 경우 (네트워크 오류 등)
-    // 에러 처리가 필요할 수 있습니다. 여기서는 일단 false 반환 또는 에러 throw 고려
-    throw new Error('이메일 중복 확인 중 오류가 발생했습니다.');
-  }
-};
 
 // 닉네임 중복 확인 API
-export const checkNicknameDuplicate = async (nickname: string): Promise<boolean> => {
-  try {
-    // 백엔드와 협의된 중복 확인 API 엔드포인트 사용
-    // 예: GET /api/v1/users/check-nickname?nickname=...
-    const response = await axiosInstance.get(API_ROUTES.CHECK_NICKNAME, { params: { nickname } });
-    console.log('닉네임 중복 확인 응답:', response);
-
-    // 백엔드 응답 구조에 따라 중복 여부를 판단합니다.
-    return response.data.isDuplicate; // <<< 백엔드 응답 구조에 맞게 수정
-  } catch (error) {
-    console.error('닉네임 중복 확인 API 호출 에러 발생:', error);
-    throw new Error('닉네임 중복 확인 중 오류가 발생했습니다.');
-  }
-};
-
-*/

--- a/src/apis/auth.api.ts
+++ b/src/apis/auth.api.ts
@@ -1,39 +1,49 @@
-import { LoginFormInputs, SignupFormInputs } from '@/interfaces/auth.interfaces';
+import { LoginFormInputs, SignupFormInputs, User } from '@/interfaces/auth.interfaces';
 import axiosInstance from '@/apis/axiosInstance.api';
 import { API_ROUTES } from '@/apis/apiRoutes';
 import { toast } from 'react-toastify';
 
 // 로그인
-export const login = async (data: LoginFormInputs) => {
+export const login = async (data: LoginFormInputs): Promise<{ accessToken: string }> => {
   try {
     const response = await axiosInstance.post(API_ROUTES.LOGIN, data);
-    console.log('로그인 응답:', response);
 
-    // accessToken이랑 user 정보 받아서 저장
+    console.log('----- 로그인 API 응답 -----');
+    console.log('로그인 응답:', response);
+    console.log('응답 데이터 (response.data): ', response.data);
+
     const accessToken = response.data.data;
     console.log('accessToken: ', accessToken);
 
-    // 수정해야함
-    const user = response.data;
-
-    // 로그인시, user 정보도 받아와야하는거 백엔드에 요청하기
-    // accessToken data말고 accessToken으로 이름 바꿔달라고 요청하기
-
     if (accessToken) {
-      // 세션 저장
-      sessionStorage.setItem('accessToken', accessToken);
-      // 성공 시 응답 객체 반환
-      return {
-        accessToken,
-        user,
-      };
+      return { accessToken };
     } else {
-      throw new Error('로그인 성공 응답에 accessToken이 없습니다.');
+      throw new Error('로그인 인증 토큰을 받지 못했습니다.');
     }
   } catch (error) {
-    console.error('로그인 API 호출 에러 발생:', error);
+    console.error('로그인 API 호출 에러 발생: ', error);
     const errorMessage = error.response?.data?.message || '알 수 없는 로그인 오류가 발생했습니다.';
     throw new Error(errorMessage);
+  }
+};
+
+// 내 정보 조회
+export const getMyInfo = async (token?: string): Promise<User> => {
+  try {
+    const response = await axiosInstance.get(API_ROUTES.MY_INFO, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+
+    console.log('----- 내 정보 API 응답 -----');
+    console.log('전체 응답 객체 : ', response);
+    console.log('응답 데이터 (response.data): ', response.data);
+
+    console.log('응답 데이터 response.data.data: ', response.data.data);
+
+    return response.data.data;
+  } catch (error) {
+    console.error('내 정보 조회 API 호출 에러 발생: ', error);
+    throw new Error('사용자 정보를 가져오는데 실패했습니다.');
   }
 };
 

--- a/src/apis/auth.api.ts
+++ b/src/apis/auth.api.ts
@@ -56,8 +56,6 @@ export const logout = async () => {
     const errorMessage =
       error.response?.data?.message || '알 수 없는 로그아웃 오류가 발생했습니다.';
     throw new Error(errorMessage);
-  } finally {
-    sessionStorage.removeItem('accessToken');
   }
 };
 

--- a/src/apis/axiosInstance.api.ts
+++ b/src/apis/axiosInstance.api.ts
@@ -1,18 +1,28 @@
 import axios from 'axios';
+import { getDefaultStore } from 'jotai';
+import { tokenAtom } from '@/atoms/auth.atom';
+
+const jotaiStore = getDefaultStore();
 
 const axiosInstance = axios.create({
   baseURL: `${import.meta.env.VITE_REACT_APP_API_HOST}`,
   timeout: 10000,
   // 쿠키에 포함
   // withCredentials: true,
-  // header에 포함
-  // headers: { authorization: `Bearer` },
 });
 
-axiosInstance.interceptors.request.use(config => {
-  const accessToken = sessionStorage.getItem('accessToken');
-  if (config.headers && accessToken) config.headers.Authorization = `Bearer ${accessToken}`;
-  return config;
-});
+axiosInstance.interceptors.request.use(
+  config => {
+    const accessToken = jotaiStore.get(tokenAtom);
+
+    if (config.headers && accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;

--- a/src/atoms/auth.atom.ts
+++ b/src/atoms/auth.atom.ts
@@ -1,0 +1,28 @@
+import { User } from '@/interfaces/auth.interfaces';
+import { atom } from 'jotai';
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+
+const storage = createJSONStorage<string | null>(() => sessionStorage);
+
+// 엑세스 토큰 관리
+export const tokenAtom = atomWithStorage<string | null>(
+  'accessToken', // sessionStorage에 저장될 key
+  null, // 초기값
+  storage,
+  { getOnInit: true } // 앱 시작 시 sessionStorage 값을 즉시 atom에 반영
+);
+
+// 로그인한 사용자 정보 관리
+// 쿠키에 뭐가 남았는지 자꾸 에러 발생
+// export const userAtom = atom<User | null>(null);
+
+export const userAtom = atom(
+  null as User | null, // 첫 번째 인자: 초기값 (타입을 명확히 하기 위해 as 사용)
+  (get, set, newUser: User | null) => {
+    // 두 번째 인자: 값을 어떻게 업데이트할지에 대한 로직
+    set(userAtom, newUser); // userAtom 자신을 새로운 값(newUser)으로 설정
+  }
+);
+
+// 로그인 여부
+export const isLoggedInAtom = atom(get => get(tokenAtom) !== null);

--- a/src/components/auth/AuthLoader.tsx
+++ b/src/components/auth/AuthLoader.tsx
@@ -1,0 +1,31 @@
+import { getMyInfo } from '@/apis/auth.api';
+import { tokenAtom, userAtom } from '@/atoms/auth.atom';
+import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+
+// 웹이 처음 로드 될 경우 인증 상태 확인 후
+// 토큰이 있을 경우 자동으로 사용자 정보 불러옴
+export default function AuthLoader() {
+  const [token, setToken] = useAtom(tokenAtom);
+  const [user, setUser] = useAtom(userAtom);
+
+  useEffect(() => {
+    const checkAuthStatus = async () => {
+      // sessionStorage에 토큰 O, 현재 user 상태 null
+      if (token && !user) {
+        try {
+          const userInfo = await getMyInfo();
+          setUser(userInfo);
+        } catch (error) {
+          console.error('자동 로그인 실패 (토큰 만료 등): ', error);
+          setToken(null);
+          setUser(null);
+        }
+      }
+    };
+
+    checkAuthStatus();
+  }, [token, user, setToken, setUser]);
+
+  return null;
+}

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { ComponentPropsWithoutRef, forwardRef } from 'react';
+import { theme } from '@/styles/theme';
 
 const sizeStyle = {
   small: {
@@ -20,9 +21,9 @@ export const ButtonStyle = styled.button<{ size: 'small' | 'medium' | 'large' }>
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: ${({ theme }) => theme.color.point};
+  background-color: ${theme.color.point};
   color: white;
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  border-radius: ${theme.borderRadius.sm};
   cursor: pointer;
   padding: ${({ size }) => sizeStyle[size].padding};
   font-size: ${({ size }) => sizeStyle[size].fontSize};

--- a/src/components/contents/leisureContents/HomeLeisureContents.style.ts
+++ b/src/components/contents/leisureContents/HomeLeisureContents.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { theme } from '@/styles/theme';
 
 export const HomeLeisureContentsStyle = styled.article`
   display: flex;
@@ -21,8 +22,8 @@ export const Image = styled.img<ImageProps>`
   width: 100%;
   height: 100%;
   object-fit: ${({ $isDefaultImage }) => ($isDefaultImage ? 'contain' : 'cover')};
-  background-color: ${({ theme }) => theme.color.loading};
-  border-radius: ${({ theme }) => theme.borderRadius.xl};
+  background-color: ${theme.color.loading};
+  border-radius: ${theme.borderRadius.xl};
 `;
 
 export const TContents = styled.div`
@@ -53,17 +54,17 @@ export const LocationWrapper = styled.div`
 
 export const Location = styled.span`
   font-size: 20px;
-  color: ${({ theme }) => theme.color.darkGray};
+  color: ${theme.color.darkGray};
 `;
 
 export const Dot = styled.span`
   font-size: 20px;
-  color: ${({ theme }) => theme.color.darkGray};
+  color: ${theme.color.darkGray};
 `;
 
 export const LocationEtc = styled.span`
   font-size: 20px;
-  color: ${({ theme }) => theme.color.darkGray};
+  color: ${theme.color.darkGray};
 `;
 
 export const Title = styled.h3`
@@ -79,7 +80,7 @@ export const Title = styled.h3`
 export const PriceWrapper = styled.div`
   display: flex;
   align-items: end;
-  color: ${({ theme }) => theme.color.bkTitle};
+  color: ${theme.color.bkTitle};
   gap: 10px;
   // 무료 && 매진일 경우
   // color: transparent;
@@ -90,7 +91,7 @@ export const DiscountRate = styled.span`
   flex-direction: row;
   font-size: 20px;
   font-weight: 550;
-  color: ${({ theme }) => theme.color.point};
+  color: ${theme.color.point};
   // 무료 && 매진일 경우
   // color: transparent;
 

--- a/src/components/contents/pagebarContents/PagebarContents.tsx
+++ b/src/components/contents/pagebarContents/PagebarContents.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import Likes from '@/components/likes/Likes';
 import Stars from '@/components/stars/Stars';
 import { GoHeartFill } from 'react-icons/go';
+import { theme } from '@/styles/theme';
 
 export const PagebarContentsStyle = styled.article`
   display: flex;
@@ -18,13 +19,13 @@ export const ContentTitle = styled.h2`
   font-size: 20px;
   font-weight: bold;
   align-items: flex-end;
-  color: ${({ theme }) => theme.color.title};
+  color: ${theme.color.title};
 
   .type {
     font-size: 16px;
     font-weight: normal;
     margin-left: 5px;
-    color: ${({ theme }) => theme.color.darkGray};
+    color: ${theme.color.darkGray};
   }
 
   .like_btn {
@@ -51,7 +52,7 @@ export const StarHeartWrapper = styled.div`
   font-size: 12px;
   gap: 2px;
   span {
-    color: ${({ theme }) => theme.color.bkTitle};
+    color: ${theme.color.bkTitle};
   }
 
   .line {
@@ -60,7 +61,7 @@ export const StarHeartWrapper = styled.div`
 `;
 
 export const HeartIcon = styled(GoHeartFill)`
-  color: ${({ theme }) => theme.color.heartR};
+  color: ${theme.color.heartR};
 `;
 
 export const PhotoWrapper = styled.div`
@@ -72,7 +73,7 @@ export const Image = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: ${({ theme }) => theme.borderRadius.md};
+    border-radius: ${theme.borderRadius.md};
 `;
 
 // 이미지, 컨텐츠 연결

--- a/src/components/contents/pagebarContents/PagebarNav.tsx
+++ b/src/components/contents/pagebarContents/PagebarNav.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@/styles/theme';
 import styled from 'styled-components';
 
 const PagebarNavStyle = styled.nav`
@@ -17,16 +18,16 @@ const NavBtn = styled.button`
   padding: 5px;
   cursor: pointer;
 
-  border-radius: ${({ theme }) => theme.borderRadius.xxl};
+  border-radius: ${theme.borderRadius.xxl};
   //버튼 선택이 된 경우
   border: 1px solid transparent;
   background:
     linear-gradient(white, white) padding-box,
-    ${({ theme }) => `linear-gradient(to right, ${theme.color.rgb1}, ${theme.color.rgb2})`}
+    ${`linear-gradient(to right, ${theme.color.rgb1}, ${theme.color.rgb2})`}
       border-box;
 
   span {
-    color: ${({ theme }) => theme.color.bkTitle};
+    color: ${theme.color.bkTitle};
     font-size: 14px;
     font-weight: 500;
   }

--- a/src/components/contents/planContents/DayButton.tsx
+++ b/src/components/contents/planContents/DayButton.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@/styles/theme';
 import styled from 'styled-components';
 
 const DayButtonStyle = styled.button`
@@ -6,14 +7,14 @@ const DayButtonStyle = styled.button`
   height: 35px;
   align-items: center;
   justify-content: center;
-  border-radius: ${({ theme }) => theme.borderRadius.xxl};
+  border-radius: ${theme.borderRadius.xxl};
   // 선택 되었을 경우 배경 색상
-  background-color: ${({ theme }) => theme.color.point};
+  background-color: ${theme.color.point};
 
   // 선택 X 벼튼 스타일
   // background-color: white;
   // border-style: solid;
-  // border-color: ${({ theme }) => theme.color.line};
+  // border-color: ${theme.color.line};
 
   span {
     font-size: 13px;
@@ -22,7 +23,7 @@ const DayButtonStyle = styled.button`
     color: white;
 
     // 비선택시 폰트 스타일
-    //color: ${({ theme }) => theme.color.gray};
+    //color: ${theme.color.gray};
   }
 `;
 

--- a/src/components/contents/planContents/PlanContents.tsx
+++ b/src/components/contents/planContents/PlanContents.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Stars from '@/components/stars/Stars';
+import { theme } from '@/styles/theme';
 
 const PlanContentsStyle = styled.article`
   display: flex;
@@ -10,7 +11,7 @@ const Image = styled.img`
   width: 72px;
   height: 96px;
   object-fit: cover;
-  border-radius: ${({ theme }) => theme.borderRadius.xs};
+  border-radius: ${theme.borderRadius.xs};
 `;
 
 const TextWrapper = styled.div`
@@ -22,17 +23,17 @@ const TextWrapper = styled.div`
   .title {
     font-size: 18px;
     font-weight: 600;
-    color: ${({ theme }) => theme.color.bkTitle};
+    color: ${theme.color.bkTitle};
   }
 
   .summary {
     font-size: 12px;
-    color: ${({ theme }) => theme.color.darkGray};
+    color: ${theme.color.darkGray};
   }
 
   .location {
     font-size: 12px;
-    color: ${({ theme }) => theme.color.gray};
+    color: ${theme.color.gray};
   }
 `;
 

--- a/src/components/contents/planContents/PlanbarContents.tsx
+++ b/src/components/contents/planContents/PlanbarContents.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@/styles/theme';
 import styled from 'styled-components';
 
 export const PlanbarContentsStyle = styled.article`
@@ -22,12 +23,12 @@ export const NumberBadge = styled.div`
   justify-content: center;
   width: 25px;
   height: 25px;
-  border-radius: ${({ theme }) => theme.borderRadius.round};
-  background-color: ${({ theme }) => theme.color.yellow};
+  border-radius: ${theme.borderRadius.round};
+  background-color: ${theme.color.yellow};
 
   font-size: 12px;
   font-weight: bold;
-  color: ${({ theme }) => theme.color.heartBg};
+  color: ${theme.color.heartBg};
 `;
 
 export const ContentsWapper = styled.div`
@@ -36,8 +37,8 @@ export const ContentsWapper = styled.div`
   justify-content: center;
   width: 85%;
   padding: 15px 17px;
-  border-radius: ${({ theme }) => theme.borderRadius.xs};
-  box-shadow: ${({ theme }) => theme.shadow.boxShadow};
+  border-radius: ${theme.borderRadius.xs};
+  box-shadow: ${theme.shadow.boxShadow};
   gap: 10px;
 
   div {
@@ -49,27 +50,27 @@ export const ContentsWapper = styled.div`
   .contentsName {
     font-size: 18px;
     font-weight: 600;
-    color: ${({ theme }) => theme.color.bkTitle};
+    color: ${theme.color.bkTitle};
     word-break: break-all;
   }
 
   .location {
     font-size: 14px;
     font-weight: 400;
-    color: ${({ theme }) => theme.color.gray};
+    color: ${theme.color.gray};
     word-break: break-all;
   }
 
   .time {
     font-size: 10px;
     font-weight: 500;
-    color: ${({ theme }) => theme.color.darkGray};
+    color: ${theme.color.darkGray};
   }
 
   .memo {
     font-size: 10px;
     font-weight: 400;
-    color: ${({ theme }) => theme.color.gray};
+    color: ${theme.color.gray};
   }
 `;
 

--- a/src/components/contents/planContents/PlanbarDayContainer.tsx
+++ b/src/components/contents/planContents/PlanbarDayContainer.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import React from 'react';
+import { theme } from '@/styles/theme';
 
 const DayContainerStyle = styled.div`
   display: flex;
@@ -17,7 +18,7 @@ const DayCountBtn = styled.button`
   .dayCount {
     font-size: 16px;
     font-weight: 500;
-    color: ${({ theme }) => theme.color.bkTitle};
+    color: ${theme.color.bkTitle};
   }
 `;
 

--- a/src/components/input/FormInput.tsx
+++ b/src/components/input/FormInput.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ErrorMessage, InputContainer, Label } from '@/styles/AuthForm.style';
+import { FieldErrors, FieldValues, Path, RegisterOptions, UseFormRegister } from 'react-hook-form';
+import Input from './Input';
+
+interface FormInputProps<T extends FieldValues> {
+  label: string;
+  name: Path<T>;
+  type?: string;
+  placeholder?: string;
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  rules?: RegisterOptions<T>;
+  disabled?: boolean;
+  defaultValue?: string;
+}
+
+export default function FormInput<T extends FieldValues>({
+  label,
+  name,
+  register,
+  errors,
+  rules,
+  ...rest
+}: FormInputProps<T>) {
+  const error = errors[name];
+
+  return (
+    <InputContainer>
+      <Label>{label}</Label>
+      {/* error O -> hasError = ture -> 테두리 빨갛게 설정 */}
+      <Input hasError={!!error} {...register(name, rules)} {...rest} />
+      {error && <ErrorMessage>{error.message as React.ReactNode}</ErrorMessage>}
+    </InputContainer>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -149,7 +149,7 @@ export default function Header({ isHome, hasMap, isLogSign }) {
   const isLoggedIn = useAtomValue(isLoggedInAtom);
   const user = useAtomValue(userAtom);
   const setToken = useSetAtom(tokenAtom);
-  const setUser = useSetAtom(tokenAtom);
+  const setUser = useSetAtom(userAtom);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -210,7 +210,7 @@ export default function Header({ isHome, hasMap, isLogSign }) {
         <DropdownItems onClick={() => navigate('/cart')}>
           <IoCartOutline /> 장바구니
         </DropdownItems>
-        <DropdownItems onClick={() => navigate('/profile')}>
+        <DropdownItems onClick={() => navigate('/mypage')}>
           <IoSettingsOutline /> 프로필 수정
         </DropdownItems>
         <DropdownItems onClick={handleLogout}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,10 @@ import { IoIosCalendar, IoMdMenu } from 'react-icons/io';
 import { useEffect, useState, useRef } from 'react';
 import Sidebar from '@/components/layout/sidebar/Sidebar';
 import { IoCartOutline, IoHeartOutline, IoLogOutOutline, IoSettingsOutline } from 'react-icons/io5';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { isLoggedInAtom, tokenAtom, userAtom } from '@/atoms/auth.atom';
+import { logout } from '@/apis/auth.api';
+import { toast } from 'react-toastify';
 
 const HeaderStyle = styled.header.withConfig({
   shouldForwardProp: prop => !['isHome', 'isLogSign'].includes(prop),
@@ -54,10 +58,21 @@ const ButtonWrapper = styled.div.withConfig({
   color: ${({ isHome, theme }) => (isHome ? 'white' : theme.color.title)};
 `;
 
-// const Button = styled.button`
-//   font-size: 16px;
-//   font-weight: 500;
-// `;
+const AuthButtonWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const AuthButton = styled.button`
+  font-size: 16px;
+  font-weight: 500;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+`;
 
 const SideMenuBtn = styled.button`
   display: flex;
@@ -114,7 +129,7 @@ export const DropdownItems = styled.div`
   color: ${({ theme }) => theme.color.bkBody};
 
   &:hover {
-    background-color: #f4f4f4;
+    background-color: ${({ theme }) => theme.color.hwhite};
   }
 `;
 
@@ -130,6 +145,11 @@ export default function Header({ isHome, hasMap, isLogSign }) {
   const [isSidebarOpen, setSidebarOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const profileRef = useRef<HTMLDivElement | null>(null);
+
+  const isLoggedIn = useAtomValue(isLoggedInAtom);
+  const user = useAtomValue(userAtom);
+  const setToken = useSetAtom(tokenAtom);
+  const setUser = useSetAtom(tokenAtom);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -151,6 +171,25 @@ export default function Header({ isHome, hasMap, isLogSign }) {
 
   const toggleDropdown = () => setIsProfileOpen(prev => !prev);
 
+  // --- 로그아웃 ---
+  const handleLogout = async () => {
+    try {
+      await logout();
+      setToken(null);
+      setUser(null);
+      setIsProfileOpen(false);
+
+      // 로그아웃 시 일단 메인페이지로 이동
+      navigate('/');
+      toast.success('성공적으로 로그아웃 되었습니다.');
+    } catch (error) {
+      console.log('로그아웃 실패: ', error);
+
+      setToken(null);
+      setUser(null);
+    }
+  };
+
   const renderProfileImage = () => {
     return <ProfileImageBox className="profile" width="42px" height="42px" />;
   };
@@ -160,7 +199,7 @@ export default function Header({ isHome, hasMap, isLogSign }) {
       <DropdownWrapper ref={dropdownRef} $isProfileOpen={isProfileOpen}>
         <UserInfo>
           <ProfileImageBox width="32px" height="32px" />
-          <DropdownText>선찌 님</DropdownText>
+          <DropdownText>{user ? `${user.nickname}님` : '사용자님'}</DropdownText>
         </UserInfo>
         <DropdownItems onClick={() => navigate('/myplan')}>
           <IoIosCalendar /> 내 일정
@@ -174,7 +213,7 @@ export default function Header({ isHome, hasMap, isLogSign }) {
         <DropdownItems onClick={() => navigate('/profile')}>
           <IoSettingsOutline /> 프로필 수정
         </DropdownItems>
-        <DropdownItems>
+        <DropdownItems onClick={handleLogout}>
           <IoLogOutOutline /> 로그아웃
         </DropdownItems>
       </DropdownWrapper>
@@ -207,30 +246,29 @@ export default function Header({ isHome, hasMap, isLogSign }) {
                 src={Triplan_r}
                 alt="rgb 로고"
                 onClick={() => navigate('/')}
-                style={{ marginLeft: '78px' }}
+                style={{ marginLeft: '78px', cursor: 'pointer' }}
               />
             </>
           )}
+          {/*---- 로그인 상태에 따른 조건부 랜더링 -----*/}
           <ButtonWrapper isHome={isHome}>
-            {/* 로그인 O 프로필 이미지 가져오기 */}
-            {/*<>*/}
-            {/*  <ProfileImgWrapper ref={profileRef} onClick={toggleDropdown}>*/}
-            {/*    {renderProfileImage()}*/}
-            {/*  </ProfileImgWrapper>*/}
-            {/*  {renderDropdown()}*/}
-            {/*</>*/}
-            {!isLogSign && (
+            {isLoggedIn ? (
+              // 로그인 상태일 때 : 프로필 이미지와 드롭다운 표시
               <>
                 <ProfileImgWrapper ref={profileRef} onClick={toggleDropdown}>
                   {renderProfileImage()}
                 </ProfileImgWrapper>
                 {renderDropdown()}
               </>
+            ) : (
+              // 로그아웃 상태일 떄 : 로그인/회원가입 버튼 표시 (로그인/회원가입 페이지 아닐 경우만)
+              !isLogSign && (
+                <AuthButtonWrapper>
+                  <AuthButton onClick={() => navigate('/login')}>로그인</AuthButton>
+                  <AuthButton onClick={() => navigate('/signup')}>회원가입</AuthButton>
+                </AuthButtonWrapper>
+              )
             )}
-
-            {/* 로그인 X 경우 */}
-            {/*<Button onClick={() => navigate('/login')}>로그인</Button>*/}
-            {/*<Button onClick={() => navigate('/signup')}>회원가입</Button>*/}
           </ButtonWrapper>
         </HeaderWrapper>
       </HeaderStyle>

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -18,8 +18,7 @@ export const SidebarStyle = styled.aside`
   left: 0;
   width: 400px;
   height: 100%;
-  background-color: #f7f8fb;
-  //background-color: white;
+  background-color: ${({ theme }) => theme.color.swhite};
   z-index: 1000;
 `;
 

--- a/src/components/profile/ProfileImageBox.tsx
+++ b/src/components/profile/ProfileImageBox.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import React from 'react';
 import penguin from './penguin.jpeg';
+import { theme } from '@/styles/theme';
 
 export const ProfileImageContainer = styled.div<{
   width: string;
@@ -11,19 +12,17 @@ export const ProfileImageContainer = styled.div<{
   justify-content: center;
   width: ${({ width }) => width};
   height: ${({ height }) => height};
-  border-radius: ${({ theme }) => theme.borderRadius.round};
+  border-radius: ${theme.borderRadius.round};
 `;
 
 export const ProfileImage = styled.img`
-  border-radius: ${({ theme }) => theme.borderRadius.round};
+  border-radius: ${theme.borderRadius.round};
   object-fit: cover;
   width: 100%;
   height: 100%;
 `;
 
 interface ProfileImageBoxProps {
-  // src?: string;
-  // alt?: string;
   width: string;
   height: string;
   className?: string;

--- a/src/hook/useLogin.ts
+++ b/src/hook/useLogin.ts
@@ -1,0 +1,55 @@
+import { getMyInfo, login } from '@/apis/auth.api';
+import { tokenAtom, userAtom } from '@/atoms/auth.atom';
+import { LoginFormInputs } from '@/interfaces/auth.interfaces';
+import { useSetAtom } from 'jotai';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import { toast } from 'react-toastify';
+
+export const useLogin = () => {
+  const navigate = useNavigate();
+  const setToken = useSetAtom(tokenAtom);
+  const setUser = useSetAtom(userAtom);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // mode: onChange시 다수의 리렌더링 발생 할 수 있음 -> 성능 체크필요
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<LoginFormInputs>({ mode: 'onChange' });
+
+  const onSubmit = async (data: LoginFormInputs) => {
+    setIsLoading(true);
+
+    try {
+      const { accessToken } = await login(data);
+      setToken(accessToken);
+
+      // 로그인 성공 후 사용자 정보 받아옴
+      const userInfo = await getMyInfo();
+      setUser(userInfo);
+
+      toast.success(`${userInfo.nickname}님, 환영합니다!`);
+      navigate('/');
+    } catch (error) {
+      // 로그인 실패시 atom 비우기
+      setToken(null);
+      setUser(null);
+
+      console.error('로그인 처리 중 에러 발생: ', error);
+      toast.error('아이디 또는 비밀번호를 확인해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    isValid,
+    isLoading,
+  };
+};

--- a/src/hook/useMy.ts
+++ b/src/hook/useMy.ts
@@ -1,0 +1,57 @@
+import { patchMyInfo } from '@/apis/auth.api';
+import { userAtom } from '@/atoms/auth.atom';
+import { UpdateMyInfoPayload } from '@/interfaces/auth.interfaces';
+import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import { toast } from 'react-toastify';
+
+type MyPageFormInputs = UpdateMyInfoPayload;
+
+export const useMy = () => {
+  const [user, setUser] = useAtom(userAtom);
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty, isValid },
+    reset,
+  } = useForm<MyPageFormInputs>({ mode: 'onChange' });
+
+  // user 정보가 Jotai에 로드시 폼의 기본값 설정
+  useEffect(() => {
+    if (user) {
+      reset({
+        nickname: user.nickname,
+        phoneNumber: user.phoneNumber,
+        password: '',
+      });
+    }
+  }, [user, reset]);
+
+  // 폼 제출 시 실행
+  const onSubmit: SubmitHandler<MyPageFormInputs> = async data => {
+    try {
+      const updatedUser = await patchMyInfo(data);
+      setUser(updatedUser); // Jotai 상태를 업데이트된 유저 정보로 교체
+
+      reset({ ...data, password: '' }); // 제출 후 폼 상태를 다시 초기화
+
+      toast.success('프로필이 성공적으로 수정되었습니다.');
+      navigate('/');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '프로필 수정에 실패했습니다.');
+    }
+  };
+
+  return {
+    user,
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    isDirty,
+    isValid,
+  };
+};

--- a/src/hook/useSignup.ts
+++ b/src/hook/useSignup.ts
@@ -1,0 +1,38 @@
+import { signUp } from '@/apis/auth.api';
+import { SignupFormInputs } from '@/interfaces/auth.interfaces';
+import { useForm, useWatch } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import { toast } from 'react-toastify';
+
+export const useSignup = () => {
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    control,
+  } = useForm<SignupFormInputs>({ mode: 'onChange' });
+
+  // 비밀번호 확인에 필요
+  const password = useWatch({ control, name: 'password' });
+
+  const onSubmit = async (data: SignupFormInputs) => {
+    try {
+      await signUp(data);
+      toast.success('회원가입이 성공적으로 완료되었습니다! 로그인 해주세요.');
+      navigate('/login');
+    } catch (error) {
+      console.error('회원가입 중 에러 발생: ', error);
+      toast.error('회원가입 시도 실패 다시 해주세용');
+    }
+  };
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    isValid,
+    password,
+  };
+};

--- a/src/interfaces/auth.interfaces.ts
+++ b/src/interfaces/auth.interfaces.ts
@@ -3,6 +3,11 @@ export interface LoginFormInputs {
   password: string;
 }
 
+export enum ROLE {
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+}
+
 export interface SignupFormInputs {
   email: string;
   nickname: string;
@@ -15,7 +20,7 @@ export interface SignupFormInputs {
 export interface User {
   email: string;
   nickname: string;
-  userRole: 'ADMIN' | 'USER';
+  userRole: ROLE;
   phoneNumber: string;
 }
 

--- a/src/interfaces/auth.interfaces.ts
+++ b/src/interfaces/auth.interfaces.ts
@@ -7,7 +7,14 @@ export interface SignupFormInputs {
   email: string;
   nickname: string;
   userRole?: 'USER';
-  phoneNumber: number;
+  phoneNumber: string;
   password: string;
   confirmPassword: string;
+}
+
+export interface User {
+  email: string;
+  nickname: string;
+  userRole: 'ADMIN' | 'USER';
+  phoneNumber: string;
 }

--- a/src/interfaces/auth.interfaces.ts
+++ b/src/interfaces/auth.interfaces.ts
@@ -18,3 +18,9 @@ export interface User {
   userRole: 'ADMIN' | 'USER';
   phoneNumber: string;
 }
+
+export interface UpdateMyInfoPayload {
+  nickname: string;
+  phoneNumber: string;
+  password: string;
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,13 +1,6 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { toast } from 'react-toastify';
-import Input from '@/components/input/Input';
 import Button from '@/components/button/Button';
-import { LoginFormInputs } from '@/interfaces/auth.interfaces';
 import {
   Contents,
-  ErrorMessage,
   Form,
   InputContainer,
   LinkContainer,
@@ -15,75 +8,46 @@ import {
   Span,
   Title,
 } from '@/styles/AuthForm.style';
-import { getMyInfo, login } from '@/apis/auth.api';
-import { useSetAtom } from 'jotai';
-import { tokenAtom, userAtom } from '@/atoms/auth.atom';
+
+import { useLogin } from '@/hook/useLogin';
+import FormInput from '@/components/input/FormInput';
 
 export default function LoginPage() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<LoginFormInputs>();
-  const navigate = useNavigate();
-
-  const setToken = useSetAtom(tokenAtom);
-  const setUser = useSetAtom(userAtom);
-
-  // 로딩상태
-  const [isLoading, setIsLoading] = useState(false);
-
-  const onSubmit: SubmitHandler<LoginFormInputs> = async data => {
-    setIsLoading(true);
-    try {
-      const { accessToken } = await login(data);
-      setToken(accessToken);
-
-      const userInfo = await getMyInfo();
-      setUser(userInfo);
-
-      toast.success(`${userInfo.nickname}님, 환영합니다!`);
-      navigate('/');
-    } catch (error) {
-      setToken(null);
-      setUser(null);
-
-      console.error('로그인 처리중 에러 발생:', error);
-      toast.error('로그인 실패');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const { register, handleSubmit, errors, isValid, isLoading } = useLogin();
 
   return (
     <Contents>
       <Title>로그인</Title>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit}>
         <InputContainer>
-          <Input
-            hasError={!!errors.email}
+          <FormInput
+            label="이메일"
+            name="email"
             type="email"
             placeholder="이메일을 입력하세요"
-            {...register('email', {
+            register={register}
+            errors={errors}
+            rules={{
               required: '이메일을 입력하세요.',
-            })}
+            }}
           />
-          {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
 
-          <Input
-            hasError={!!errors.password}
+          <FormInput
+            label="비밀번호"
+            name="password"
             type="password"
             placeholder="비밀번호를 입력하세요"
-            {...register('password', {
+            register={register}
+            errors={errors}
+            rules={{
               required: '비밀번호를 입력하세요.',
-            })}
+            }}
           />
-          {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
 
-          {/* 로딩 상태에 따라 버튼 비활성화 */}
-          <Button type="submit" size="large" disabled={isLoading}>
-            로그인
+          <Button type="submit" size="large" disabled={!isValid || isLoading}>
+            {isLoading ? '로그인 중...' : '로그인'}
           </Button>
+
           <LinkContainer>
             <Span>아직 회원이 아니신가요?</Span>
             <LinkStyle to={'/signup'}>회원가입</LinkStyle>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,104 +1,3 @@
-// import React, { useState } from 'react';
-// import { useNavigate } from 'react-router';
-// import { SubmitHandler, useForm } from 'react-hook-form';
-// import { toast } from 'react-toastify';
-// import Input from '@/components/input/Input';
-// import Button from '@/components/button/Button';
-// import { LoginFormInputs } from '@/interfaces/auth.interfaces';
-// import {
-//   Contents,
-//   ErrorMessage,
-//   Form,
-//   InputContainer,
-//   LinkContainer,
-//   LinkStyle,
-//   Span,
-//   Title,
-// } from '@/styles/AuthForm.style';
-// import { login } from '@/apis/auth.api';
-// import { useSetAtom } from 'jotai';
-// import { authAtom } from '@/atoms/auth';
-
-// export default function LoginPage() {
-//   const {
-//     register,
-//     handleSubmit,
-//     formState: { errors },
-//   } = useForm<LoginFormInputs>();
-//   const navigate = useNavigate();
-
-//   // 인증 상태 업데이트
-//   const setAuth = useSetAtom(authAtom);
-//   // 로딩상태
-//   const [isLoading, setIsLoading] = useState(false);
-
-//   const onSubmit: SubmitHandler<LoginFormInputs> = async data => {
-//     setIsLoading(true);
-//     try {
-//       // login 함수 호출 및 응답
-//       const loginResponse = await login(data);
-
-//       // login 함수에서 반환된 accessToken, user 정보 업데이트
-//       setAuth({
-//         isAuthenticated: true,
-//         user: loginResponse.user || null,
-//         accessToken: loginResponse.accessToken,
-//         isLoading: false,
-//         error: null,
-//       });
-
-//       // 로그인 성공 시 토스트 메시지 표시
-//       toast.success('로그인 성공');
-//       navigate('/');
-//     } catch (error) {
-//       console.error('로그인 처리중 에러 발생:', error);
-//       const errorMessage = error.message || '로그인에 실패했습니다.';
-//       toast.error(errorMessage);
-//       // toast.error('로그인 실패');
-//     } finally {
-//       setIsLoading(false);
-//     }
-//   };
-
-//   return (
-//     <Contents>
-//       <Title>로그인</Title>
-//       <Form onSubmit={handleSubmit(onSubmit)}>
-//         <InputContainer>
-//           <Input
-//             hasError={!!errors.email}
-//             type="email"
-//             placeholder="이메일을 입력하세요"
-//             {...register('email', {
-//               required: '이메일을 입력하세요.',
-//             })}
-//           />
-//           {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
-
-//           <Input
-//             hasError={!!errors.password}
-//             type="password"
-//             placeholder="비밀번호를 입력하세요"
-//             {...register('password', {
-//               required: '비밀번호를 입력하세요.',
-//             })}
-//           />
-//           {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
-
-//           {/* 로딩 상태에 따라 버튼 비활성화 */}
-//           <Button type="submit" size="large" disabled={isLoading}>
-//             로그인
-//           </Button>
-//           <LinkContainer>
-//             <Span>아직 회원이 아니신가요?</Span>
-//             <LinkStyle to={'/signup'}>회원가입</LinkStyle>
-//           </LinkContainer>
-//         </InputContainer>
-//       </Form>
-//     </Contents>
-//   );
-// }
-
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -116,7 +15,9 @@ import {
   Span,
   Title,
 } from '@/styles/AuthForm.style';
-import { login } from '@/apis/auth.api';
+import { getMyInfo, login } from '@/apis/auth.api';
+import { useSetAtom } from 'jotai';
+import { tokenAtom, userAtom } from '@/atoms/auth.atom';
 
 export default function LoginPage() {
   const {
@@ -126,16 +27,27 @@ export default function LoginPage() {
   } = useForm<LoginFormInputs>();
   const navigate = useNavigate();
 
+  const setToken = useSetAtom(tokenAtom);
+  const setUser = useSetAtom(userAtom);
+
   // 로딩상태
   const [isLoading, setIsLoading] = useState(false);
 
   const onSubmit: SubmitHandler<LoginFormInputs> = async data => {
     setIsLoading(true);
     try {
-      await login(data);
-      toast.success('로그인 성공');
+      const { accessToken } = await login(data);
+      setToken(accessToken);
+
+      const userInfo = await getMyInfo();
+      setUser(userInfo);
+
+      toast.success(`${userInfo.nickname}님, 환영합니다!`);
       navigate('/');
     } catch (error) {
+      setToken(null);
+      setUser(null);
+
       console.error('로그인 처리중 에러 발생:', error);
       toast.error('로그인 실패');
     } finally {

--- a/src/pages/auth/MyPage.tsx
+++ b/src/pages/auth/MyPage.tsx
@@ -1,3 +1,190 @@
-export default function MyPage() {
-  return <div>MyPage</div>;
+import { useEffect } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { useAtom } from 'jotai';
+import { userAtom } from '@/atoms/auth.atom';
+import { toast } from 'react-toastify';
+import styled from 'styled-components';
+
+import {
+  Contents,
+  Title,
+  Form,
+  InputContainer,
+  Label,
+  ErrorMessage,
+} from '@/styles/AuthForm.style';
+import Input from '@/components/input/Input';
+import Button from '@/components/button/Button';
+import ProfileImageBox from '@/components/profile/ProfileImageBox';
+import { FaCamera } from 'react-icons/fa';
+import { patchMyInfo } from '@/apis/auth.api';
+import { UpdateMyInfoPayload } from '@/interfaces/auth.interfaces';
+import { useNavigate } from 'react-router';
+
+const ProfileSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+`;
+
+const ProfileImageWrapper = styled.div`
+  position: relative;
+  width: 120px;
+  height: 120px;
+`;
+
+// S3 서버 완료 되면 수정 예정
+const EditButton = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background-color: ${({ theme }) => theme.color.point};
+  color: white;
+  border-radius: 50%;
+  border: 2px solid white;
+  cursor: pointer;
+  font-size: 18px;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+`;
+
+type MypageFormInputs = UpdateMyInfoPayload;
+
+export default function Mypage() {
+  const [user, setUser] = useAtom(userAtom);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty, isValid },
+    reset,
+  } = useForm<MypageFormInputs>({ mode: 'onChange' });
+
+  const navigate = useNavigate();
+
+  // user 정보가 Jotai에 로드시 폼의 기본값 설정
+  useEffect(() => {
+    if (user) {
+      reset({
+        nickname: user.nickname,
+        phoneNumber: user.phoneNumber,
+        password: '',
+      });
+    }
+  }, [user, reset]);
+
+  const onSubmit: SubmitHandler<MypageFormInputs> = async data => {
+    try {
+      const updatedUser = await patchMyInfo(data);
+      setUser(updatedUser);
+
+      reset({ ...data, password: '' });
+
+      toast.success('프로필이 성공적으로 수정되었습니다.');
+
+      // 수정 완료시 일단 메인화면으로 이동
+      navigate('/');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '프로필 수정에 실패했습니다.');
+    }
+  };
+
+  // Jotai에서 user 정보를 불러오지 못했을 경우
+  if (!user) {
+    return (
+      <Contents>
+        <Title>로딩 중...</Title>
+      </Contents>
+    );
+  }
+
+  return (
+    <Contents>
+      <Title>프로필 수정</Title>
+      <Form onSubmit={handleSubmit(onSubmit)}>
+        <ProfileSection>
+          <ProfileImageWrapper>
+            <ProfileImageBox width="120px" height="120px" />
+            <EditButton>
+              <FaCamera />
+            </EditButton>
+          </ProfileImageWrapper>
+        </ProfileSection>
+
+        <InputContainer>
+          <InputContainer>
+            <Label>이메일</Label>
+            <Input
+              type="email"
+              defaultValue={user.email}
+              disabled
+              style={{ backgroundColor: '#f2f2f2', cursor: 'not-allowed' }}
+            />
+          </InputContainer>
+
+          <InputContainer>
+            <Label>닉네임</Label>
+            <Input
+              hasError={!!errors.nickname}
+              type="text"
+              {...register('nickname', {
+                required: '닉네임을 입력하세요.',
+                pattern: {
+                  value: /^[a-zA-Z가-힣0-9]{2,8}$/,
+                  message: '닉네임은 영어, 한글, 숫자로 구성된 2~8글자여야 합니다.',
+                },
+              })}
+            />
+            {errors.nickname && <ErrorMessage>{errors.nickname.message}</ErrorMessage>}
+          </InputContainer>
+
+          {/* 백엔드 수정되면 전화번호도 바뀔 듯 */}
+          <InputContainer>
+            <Label>전화번호</Label>
+            <Input
+              hasError={!!errors.phoneNumber}
+              type="tel"
+              {...register('phoneNumber', {
+                required: '전화번호를 입력하세요.',
+                pattern: {
+                  value: /^[0-9]{11}$/,
+                  message: '전화번호는 01012341234 형식의 11자리 숫자여야 합니다.',
+                },
+              })}
+            />
+            {errors.phoneNumber && <ErrorMessage>{errors.phoneNumber.message}</ErrorMessage>}
+          </InputContainer>
+
+          {/* 백엔드에서 비밀번호 일치하는지 확인하는거 필요할듯 그냥 비밀번호가 바로 바뀜 */}
+          <InputContainer>
+            <Label>비밀번호</Label>
+            <Input
+              hasError={!!errors.password}
+              type="password"
+              placeholder="정보를 수정하려면 현재 비밀번호를 입력하세요."
+              {...register('password', {
+                required: '정보를 수정하려면 비밀번호를 입력해야 합니다.',
+              })}
+            />
+            {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
+          </InputContainer>
+
+          <Button type="submit" size="large" disabled={!isDirty || !isValid}>
+            수정하기
+          </Button>
+        </InputContainer>
+      </Form>
+    </Contents>
+  );
 }

--- a/src/pages/auth/MyPage.tsx
+++ b/src/pages/auth/MyPage.tsx
@@ -1,25 +1,12 @@
-import { useEffect } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
-import { useAtom } from 'jotai';
-import { userAtom } from '@/atoms/auth.atom';
-import { toast } from 'react-toastify';
 import styled from 'styled-components';
-
-import {
-  Contents,
-  Title,
-  Form,
-  InputContainer,
-  Label,
-  ErrorMessage,
-} from '@/styles/AuthForm.style';
+import { Contents, Title, Form, InputContainer, Label } from '@/styles/AuthForm.style';
 import Input from '@/components/input/Input';
 import Button from '@/components/button/Button';
 import ProfileImageBox from '@/components/profile/ProfileImageBox';
 import { FaCamera } from 'react-icons/fa';
-import { patchMyInfo } from '@/apis/auth.api';
+import { useMy } from '@/hook/useMy';
+import FormInput from '@/components/input/FormInput';
 import { UpdateMyInfoPayload } from '@/interfaces/auth.interfaces';
-import { useNavigate } from 'react-router';
 
 const ProfileSection = styled.div`
   display: flex;
@@ -59,46 +46,8 @@ const EditButton = styled.div`
   }
 `;
 
-type MypageFormInputs = UpdateMyInfoPayload;
-
 export default function Mypage() {
-  const [user, setUser] = useAtom(userAtom);
-
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isDirty, isValid },
-    reset,
-  } = useForm<MypageFormInputs>({ mode: 'onChange' });
-
-  const navigate = useNavigate();
-
-  // user 정보가 Jotai에 로드시 폼의 기본값 설정
-  useEffect(() => {
-    if (user) {
-      reset({
-        nickname: user.nickname,
-        phoneNumber: user.phoneNumber,
-        password: '',
-      });
-    }
-  }, [user, reset]);
-
-  const onSubmit: SubmitHandler<MypageFormInputs> = async data => {
-    try {
-      const updatedUser = await patchMyInfo(data);
-      setUser(updatedUser);
-
-      reset({ ...data, password: '' });
-
-      toast.success('프로필이 성공적으로 수정되었습니다.');
-
-      // 수정 완료시 일단 메인화면으로 이동
-      navigate('/');
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : '프로필 수정에 실패했습니다.');
-    }
-  };
+  const { user, register, handleSubmit, errors, isDirty, isValid } = useMy();
 
   // Jotai에서 user 정보를 불러오지 못했을 경우
   if (!user) {
@@ -112,7 +61,7 @@ export default function Mypage() {
   return (
     <Contents>
       <Title>프로필 수정</Title>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit}>
         <ProfileSection>
           <ProfileImageWrapper>
             <ProfileImageBox width="120px" height="120px" />
@@ -133,52 +82,47 @@ export default function Mypage() {
             />
           </InputContainer>
 
-          <InputContainer>
-            <Label>닉네임</Label>
-            <Input
-              hasError={!!errors.nickname}
-              type="text"
-              {...register('nickname', {
-                required: '닉네임을 입력하세요.',
-                pattern: {
-                  value: /^[a-zA-Z가-힣0-9]{2,8}$/,
-                  message: '닉네임은 영어, 한글, 숫자로 구성된 2~8글자여야 합니다.',
-                },
-              })}
-            />
-            {errors.nickname && <ErrorMessage>{errors.nickname.message}</ErrorMessage>}
-          </InputContainer>
+          <FormInput<UpdateMyInfoPayload>
+            label="닉네임"
+            name="nickname"
+            register={register}
+            errors={errors}
+            rules={{
+              required: '닉네임을 입력하세요.',
+              pattern: {
+                value: /^[a-zA-Z가-힣0-9]{2,8}$/,
+                message: '닉네임은 영어, 한글, 숫자로 구성된 2~8글자여야 합니다.',
+              },
+            }}
+          />
 
-          {/* 백엔드 수정되면 전화번호도 바뀔 듯 */}
-          <InputContainer>
-            <Label>전화번호</Label>
-            <Input
-              hasError={!!errors.phoneNumber}
-              type="tel"
-              {...register('phoneNumber', {
-                required: '전화번호를 입력하세요.',
-                pattern: {
-                  value: /^[0-9]{11}$/,
-                  message: '전화번호는 01012341234 형식의 11자리 숫자여야 합니다.',
-                },
-              })}
-            />
-            {errors.phoneNumber && <ErrorMessage>{errors.phoneNumber.message}</ErrorMessage>}
-          </InputContainer>
+          <FormInput<UpdateMyInfoPayload>
+            label="전화번호"
+            name="phoneNumber"
+            type="tel"
+            register={register}
+            errors={errors}
+            rules={{
+              required: '전화번호를 입력하세요.',
+              pattern: {
+                value: /^[0-9]{11}$/,
+                message: '전화번호는 01012341234 형식의 11자리 숫자여야 합니다.',
+              },
+            }}
+          />
 
           {/* 백엔드에서 비밀번호 일치하는지 확인하는거 필요할듯 그냥 비밀번호가 바로 바뀜 */}
-          <InputContainer>
-            <Label>비밀번호</Label>
-            <Input
-              hasError={!!errors.password}
-              type="password"
-              placeholder="정보를 수정하려면 현재 비밀번호를 입력하세요."
-              {...register('password', {
-                required: '정보를 수정하려면 비밀번호를 입력해야 합니다.',
-              })}
-            />
-            {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
-          </InputContainer>
+          <FormInput<UpdateMyInfoPayload>
+            label="비밀번호"
+            name="password"
+            type="password"
+            placeholder="정보를 수정하려면 현재 비밀번호를 입력하세요."
+            register={register}
+            errors={errors}
+            rules={{
+              required: '정보를 수정하려면 비밀번호를 입력해야 합니다.',
+            }}
+          />
 
           <Button type="submit" size="large" disabled={!isDirty || !isValid}>
             수정하기

--- a/src/pages/auth/MyPage.tsx
+++ b/src/pages/auth/MyPage.tsx
@@ -9,6 +9,7 @@ import FormInput from '@/components/input/FormInput';
 import { UpdateMyInfoPayload } from '@/interfaces/auth.interfaces';
 import { theme } from '@/styles/theme';
 
+
 const ProfileSection = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/auth/MyPage.tsx
+++ b/src/pages/auth/MyPage.tsx
@@ -7,6 +7,7 @@ import { FaCamera } from 'react-icons/fa';
 import { useMy } from '@/hook/useMy';
 import FormInput from '@/components/input/FormInput';
 import { UpdateMyInfoPayload } from '@/interfaces/auth.interfaces';
+import { theme } from '@/styles/theme';
 
 const ProfileSection = styled.div`
   display: flex;
@@ -33,7 +34,7 @@ const EditButton = styled.div`
   justify-content: center;
   width: 36px;
   height: 36px;
-  background-color: ${({ theme }) => theme.color.point};
+  background-color: ${theme.color.point};
   color: white;
   border-radius: 50%;
   border: 2px solid white;
@@ -78,7 +79,7 @@ export default function Mypage() {
               type="email"
               defaultValue={user.email}
               disabled
-              style={{ backgroundColor: '#f2f2f2', cursor: 'not-allowed' }}
+              style={{ backgroundColor: theme.color.hwhite, cursor: 'not-allowed' }}
             />
           </InputContainer>
 

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -1,119 +1,104 @@
 import {
   Contents,
-  ErrorMessage,
   Form,
   InputContainer,
-  Label,
   LinkContainer,
   LinkStyle,
   Span,
   Title,
 } from '@/styles/AuthForm.style';
-// import React, { useState } from 'react';
-import { SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { SignupFormInputs } from '@/interfaces/auth.interfaces';
-import { useNavigate } from 'react-router';
-import Input from '@/components/input/Input';
 // import useDebounce from '@/hook/useDebounce';
-import { signUp } from '@/apis/auth.api';
 import Button from '@/components/button/Button';
+import FormInput from '@/components/input/FormInput';
+import { useSignup } from '@/hook/useSignup';
 
 export default function SignUpPage() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isValid },
-    control,
-  } = useForm<SignupFormInputs>({ mode: 'onChange' });
-
-  const navigate = useNavigate();
+  const { register, handleSubmit, errors, isValid, password } = useSignup();
 
   // 중복확인 있어야할듯
   // const [emailDuplicateError, setEmailDuplicateError] = useState<string | null>(null);
   // const [nicknameDuplicateError, setNicknameDuplicateError] = useState<string | null>(null);
 
   // const email = useWatch({ control, name: 'email' });
-  // const nickname = useWatch({ control, name: 'nickname' });
-  const password = useWatch({ control, name: 'password' });
-
-  const onSubmit: SubmitHandler<SignupFormInputs> = async data => {
-    await signUp(data);
-    navigate('/login');
-    alert('회원가입이 성공적으로 완료되었습니다.');
-  };
+  // const nickname = useWatch({ control, name: 'nickname' })
 
   return (
     <Contents>
       <Title>회원가입</Title>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit}>
         <InputContainer>
-          <Label>이메일</Label>
-          <Input
-            hasError={!!errors.email}
+          <FormInput<SignupFormInputs>
+            label="이메일"
+            name="email"
             type="email"
             placeholder="이메일을 입력하세요"
-            {...register('email', {
+            register={register}
+            errors={errors}
+            rules={{
               required: '이메일을 입력하세요.',
-            })}
+            }}
           />
-          {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
 
-          <Label>닉네임</Label>
-          <Input
-            hasError={!!errors.nickname}
-            type="text"
+          <FormInput<SignupFormInputs>
+            label="닉네임"
+            name="nickname"
             placeholder="닉네임을 입력하세요"
-            {...register('nickname', {
+            register={register}
+            errors={errors}
+            rules={{
               required: '닉네임을 입력하세요.',
               pattern: {
                 value: /^[a-zA-Z가-힣0-9]{2,8}$/,
                 message: '닉네임은 영어, 한글, 숫자로 구성된 2~8글자여야 합니다.',
               },
-            })}
+            }}
           />
-          {errors.nickname && <ErrorMessage>{errors.nickname.message}</ErrorMessage>}
 
-          <Label>전화번호</Label>
-          <Input
-            hasError={!!errors.phoneNumber}
+          <FormInput<SignupFormInputs>
+            label="전화번호"
+            name="phoneNumber"
             type="tel"
-            placeholder="예 01012341234"
-            {...register('phoneNumber', {
+            placeholder="예: 01012341234"
+            register={register}
+            errors={errors}
+            rules={{
               required: '전화번호를 입력하세요.',
               pattern: {
-                value: /[0-9]{11}/,
-                message: '전화번호는 01012341234형식으로 된 11자리 숫자여야 합니다.',
+                value: /^[0-9]{11}$/,
+                message: '전화번호는 01012341234 형식의 11자리 숫자여야 합니다.',
               },
-            })}
+            }}
           />
-          {errors.phoneNumber && <ErrorMessage>{errors.phoneNumber.message}</ErrorMessage>}
 
-          <Label>비밀번호</Label>
-          <Input
-            hasError={!!errors.password}
+          <FormInput<SignupFormInputs>
+            label="비밀번호"
+            name="password"
             type="password"
             placeholder="비밀번호를 입력하세요"
-            {...register('password', {
+            register={register}
+            errors={errors}
+            rules={{
               required: '비밀번호를 입력하세요.',
               pattern: {
                 value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#%^*_+=-]).{6,16}$/,
                 message: '비밀번호는 영어, 숫자, 특수문자를 포함한 6~16글자여야 합니다.',
               },
-            })}
+            }}
           />
-          {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
 
-          <Label>비밀번호 확인</Label>
-          <Input
-            hasError={!!errors.confirmPassword}
+          <FormInput<SignupFormInputs>
+            label="비밀번호 확인"
+            name="confirmPassword"
             type="password"
             placeholder="비밀번호를 한번 더 입력하세요."
-            {...register('confirmPassword', {
+            register={register}
+            errors={errors}
+            rules={{
               required: '비밀번호를 한번 더 입력하세요',
               validate: value => value === password || '비밀번호가 일치하지 않습니다.',
-            })}
+            }}
           />
-          {errors.confirmPassword && <ErrorMessage>{errors.confirmPassword.message}</ErrorMessage>}
 
           <Button type="submit" size="large" disabled={!isValid}>
             회원가입

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -2,15 +2,17 @@ import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
 
 const GlobalStyles = createGlobalStyle`
+    /* @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&family=Roboto:wght@400&display=swap'); */
+    
     ${reset}
 
-    @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&family=Roboto:wght@400&display=swap');
     
     @font-face {
         font-family: "Noto Sans KR";
+        src: url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&family=Roboto:wght@400&display=swap');
         font-style: normal;
     }
-    
+
     * {
         box-sizing: border-box;
         padding: 0;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -18,7 +18,9 @@ export type ColorKey =
   | 'loading'
   | 'star'
   | 'footer'
-  | 'warn';
+  | 'warn'
+  | 'hwhite'
+  | 'swhite';
 
 export type Shadows = string;
 
@@ -52,6 +54,8 @@ export const theme: DefaultTheme = {
     star: '#FFC107',
     footer: '#F7F6F6',
     warn: '#FA6554',
+    hwhite: '#f4f4f4',
+    swhite: '#f8f7fb',
   },
 
   borderRadius: {


### PR DESCRIPTION
## 📄 Summary
> 마이페이지 구현
<img width="865" height="486" alt="스크린샷 2025-08-16 오전 3 14 25" src="https://github.com/user-attachments/assets/db9b1b96-5767-4697-a90b-d2ce8edb941e" />
 

> 로그인 시 헤더의 드롭바에 닉네임 보임
<img width="863" height="485" alt="스크린샷 2025-08-16 오전 3 15 00" src="https://github.com/user-attachments/assets/686b6cbe-1ac6-494d-a872-1c4994892a00" />

> 로그인이 아닐 경우 로그인 / 회원가입이 헤더에 보임
<img width="863" height="486" alt="스크린샷 2025-08-16 오전 3 15 40" src="https://github.com/user-attachments/assets/0afaff6e-f3d8-418a-8f5d-02000c4e20b5" />


## 🙋🏻 More
1. 백엔드쪽에서 전화번호 수정이 안되어 전화번호 수정은 현재 안됨
-> 백엔드 코드 수정되면 전화번호도 수정됨

2. 백엔드 쪽에서 내 정보 수정 전에 현재 비밀번호 비교하는 코드 필요할 듯 (혹은 비밀번호는 수정 못하게)
-> 지금은 그냥 비밀번호가 바로 바뀌어버림




## ✨issue
>  - closed #13 